### PR TITLE
Removing tagsinput

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,6 @@ gem 'nprogress-rails'
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-mumuki-styles', '1.3.0'
-  gem 'rails-assets-bootstrap-tagsinput'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,7 +177,6 @@ GEM
       rails-assets-jquery (>= 1.9.1, < 4)
     rails-assets-bootstrap-sass-official (3.2.0.2)
       rails-assets-jquery (>= 1.9.0)
-    rails-assets-bootstrap-tagsinput (0.3.14)
     rails-assets-bootswatch-scss (3.2.0)
       rails-assets-bootstrap-sass-official (~> 3.2.0)
     rails-assets-dev-awesome (0.3.0)
@@ -300,7 +299,6 @@ DEPENDENCIES
   pry-remote
   puma (~> 3.0)
   rails (~> 5.0.0, >= 5.0.0.1)
-  rails-assets-bootstrap-tagsinput!
   rails-assets-mumuki-styles (= 1.3.0)!
   rspec-rails (~> 3.5)
   sass-rails (~> 5.0)


### PR DESCRIPTION
Removing taginput which is producing installation errors: 

```
$ bundle install
Don't run Bundler as root. Bundler can ask for sudo if it is needed, and installing your bundle as root will break this application for all non-root users on this machine.
Warning: the running version of Bundler (1.13.7) is older than the version that created the lockfile (1.16.0.pre.3). We suggest you upgrade to the latest version of Bundler by running `gem install bundler --pre`.
Fetching gem metadata from https://rails-assets.org/..
Retrying dependency api due to error (2/4): Bundler::HTTPError Network error while fetching https://rails-assets.org/api/v1/dependencies?gems=rails-assets-Font-Awesome%2Crails-assets-twbs--bootstrap-sass%2Crails-assets-angular%2Crails-assets-jasmine%2Crails-assets-rainbow%2Crails-assets-bootstrap-3%2Crails-assets-typeahead.js%2Crails-assets-bootstrap-2.3.2%2Crails-assets-sass-bootstrap
Retrying dependency api due to error (3/4): Bundler::HTTPError Network error while fetching https://rails-assets.org/api/v1/dependencies?gems=rails-assets-Font-Awesome%2Crails-assets-twbs--bootstrap-sass%2Crails-assets-angular%2Crails-assets-jasmine%2Crails-assets-rainbow%2Crails-assets-bootstrap-3%2Crails-assets-typeahead.js%2Crails-assets-bootstrap-2.3.2%2Crails-assets-sass-bootstrap
Retrying dependency api due to error (4/4): Bundler::HTTPError Network error while fetching https://rails-assets.org/api/v1/dependencies?gems=rails-assets-Font-Awesome%2Crails-assets-twbs--bootstrap-sass%2Crails-assets-angular%2Crails-assets-jasmine%2Crails-assets-rainbow%2Crails-assets-bootstrap-3%2Crails-assets-typeahead.js%2Crails-assets-bootstrap-2.3.2%2Crails-assets-sass-bootstrap

Fetching gem metadata from https://rubygems.org/.............
Fetching version metadata from https://rubygems.org/Net::HTTPNotFound
```
